### PR TITLE
Run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This action inserts a MultiDocumenter-style top navigation bar to `Documenter.jl
 - name: Add Navbar
   uses: shravanngoswamii/DocsNav@v1
   with:
-    navbar-url: 'URL of the navbar HTML to be inserted.'
+    doc-path: 'Path to the Documenter.jl output', default: 'docs/build'
+    navbar-url: 'URL of the navbar HTML to be inserted.', default: 'https://raw.githubusercontent.com/TuringLang/turinglang.github.io/main/assets/scripts/TuringNavbar.html'
     exclude-paths: 'Comma-separated list of paths to exclude from navbar insertion.'
-    token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -31,11 +31,11 @@ runs:
       run: |
         chmod +x ${{ github.action_path }}/scripts/insert_navbar.sh
         ${{ github.action_path }}/scripts/insert_navbar.sh . "${{ inputs.navbar-url }}" --exclude "${{ inputs.exclude-paths }}"
-        if [[ -n $(git status -s) ]]; then
-          git add .
-          git commit -m "Added navbar using insert_navbar.sh"
-          git push "https://${{ github.actor }}:${{ inputs.token }}@github.com/${{ github.repository }}.git" gh-pages
-        else
-          echo "No changes to commit"
-        fi
+        # if [[ -n $(git status -s) ]]; then
+        #   git add .
+        #   git commit -m "Added navbar using insert_navbar.sh"
+        #   git push "https://${{ github.actor }}:${{ inputs.token }}@github.com/${{ github.repository }}.git" gh-pages
+        # else
+        #   echo "No changes to commit"
+        # fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   navbar-url:
     description: 'URL of the navbar HTML to be inserted.'
     required: false
-    default: ${{ github.action_path }}/scripts/TuringNavbar.html
+    default: 'https://raw.githubusercontent.com/TuringLang/turinglang.github.io/main/assets/scripts/TuringNavbar.html'
   exclude-paths:
     description: 'Comma-separated list of paths to exclude from navbar insertion.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -14,29 +14,13 @@ inputs:
     description: 'Comma-separated list of paths to exclude from navbar insertion.'
     required: false
     default: ''
-  token:
-    description: 'GitHub token for authentication'
-    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Configure Git
-      run: |
-        git config user.name github-actions[bot]
-        git config user.email github-actions[bot]@users.noreply.github.com
-      shell: bash
-
     - name: Update Navbar
       working-directory: ${{ inputs.doc-path }}
       run: |
         chmod +x ${{ github.action_path }}/scripts/insert_navbar.sh
         ${{ github.action_path }}/scripts/insert_navbar.sh . "${{ inputs.navbar-url }}" --exclude "${{ inputs.exclude-paths }}"
-        # if [[ -n $(git status -s) ]]; then
-        #   git add .
-        #   git commit -m "Added navbar using insert_navbar.sh"
-        #   git push "https://${{ github.actor }}:${{ inputs.token }}@github.com/${{ github.repository }}.git" gh-pages
-        # else
-        #   echo "No changes to commit"
-        # fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   navbar-url:
     description: 'URL of the navbar HTML to be inserted.'
     required: false
-    default: 'https://raw.githubusercontent.com/TuringLang/turinglang.github.io/main/assets/scripts/TuringNavbar.html'
+    default: ${{ github.action_path }}/scripts/TuringNavbar.html
   exclude-paths:
     description: 'Comma-separated list of paths to exclude from navbar insertion.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,8 @@ inputs:
     default: 'docs/build'
   navbar-url:
     description: 'URL of the navbar HTML to be inserted.'
-    required: true
+    required: false
+    default: 'https://raw.githubusercontent.com/TuringLang/turinglang.github.io/main/assets/scripts/TuringNavbar.html'
   exclude-paths:
     description: 'Comma-separated list of paths to exclude from navbar insertion.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,11 @@
 name: 'Add Navbar Action'
-description: 'Adds a top navigation bar to Documenter.jl-generated sites in the gh-pages branch.'
+description: 'Adds a top navigation bar to Documenter.jl-generated sites'
 inputs:
+  doc-path:
+    description: 'Path to the Documenter.jl output'
+    required: false
+    # Most julia projects have it here
+    default: 'docs/build'
   navbar-url:
     description: 'URL of the navbar HTML to be inserted.'
     required: true
@@ -11,20 +16,18 @@ inputs:
   token:
     description: 'GitHub token for authentication'
     required: true
+
 runs:
   using: "composite"
   steps:
-    - name: Checkout gh-pages
-      uses: actions/checkout@v4
-      with:
-        ref: gh-pages
-        fetch-depth: 0
     - name: Configure Git
       run: |
         git config user.name github-actions[bot]
         git config user.email github-actions[bot]@users.noreply.github.com
       shell: bash
+
     - name: Update Navbar
+      working-directory: ${{ inputs.doc-path }}
       run: |
         chmod +x ${{ github.action_path }}/scripts/insert_navbar.sh
         ${{ github.action_path }}/scripts/insert_navbar.sh . "${{ inputs.navbar-url }}" --exclude "${{ inputs.exclude-paths }}"


### PR DESCRIPTION
Finally getting around to this after a very long time 😓😓

This PR isn't entirely complete; but I changed one thing: instead of checking out the docs source from gh-pages, instead run it on the locally generated Documenter.jl output. The benefit of this is that we don't need to have a second workflow which only serves to add the navbar, we can just have one single docs workflow. It also means less messing around with ssh keys / tokens.

The downside is that we need to split up the calls to `makedocs` and `deploydocs` in our `docs/make.jl` file. I think that's a fairly small problem, in fact, even the call to deploydocs() could be abstracted out too.

Here's an example of the corresponding Docs action:

https://github.com/penelopeysm/Shaymin.jl/blob/main/.github/workflows/docs.yml

The result:

https://github.com/penelopeysm/Shaymin.jl/actions/runs/11694770458/job/32569027575

https://pysm.dev/Shaymin.jl/dev/