### PR TITLE
Add Format action

### DIFF
--- a/Format/action.yml
+++ b/Format/action.yml
@@ -1,0 +1,31 @@
+name: 'Format'
+author: 'TuringLang'
+description: 'Run JuliaFormatter on the repository'
+inputs:
+  suggest-changes:
+    description: 'Whether to suggest changes on PRs. Defaults to true'
+    required: false
+    default: 'true'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: 1
+
+    - name: Format code
+      run: |
+        using Pkg
+        Pkg.add(; name="JuliaFormatter", uuid="98e50ef6-434e-11e9-1051-2b60c6c9e899")
+        using JuliaFormatter
+        format("."; verbose=true)
+      shell: julia --color=yes {0}
+
+    - uses: reviewdog/action-suggester@v1
+      if: ${{ inputs.suggest-changes && github.event_name == 'pull_request' }}
+      with:
+        tool_name: JuliaFormatter
+        fail_on_error: true

--- a/README.md
+++ b/README.md
@@ -79,3 +79,42 @@ jobs:
 | `doc-make-path` | Path to the `make.jl` file | `docs/make.jl` (following Documenter.jl conventions) |
 | `julia-version` | Julia version to use | `'1'` |
 | `exclude-paths` | Comma-separated list of paths to exclude from navbar insertion | `""` |
+
+
+## Format
+
+Run JuliaFormatter on the content in the repository.
+
+### Example usage
+
+```yaml
+name: Format
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Format code
+        uses: TuringLang/actions/Format@v2
+```
+
+### Parameters
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `suggest-changes` | Whether to comment on PRs with suggested changes | `"true"` |


### PR DESCRIPTION
Generalise e.g. https://github.com/TuringLang/DynamicPPL.jl/blob/master/.github/workflows/Format.yml.

I _think_ this might be the last action that is worth putting here. There are actions for tests as well, but the structure of tests tend to differ between repos, so they aren't as easily generalisable.