### PR TITLE
Fix navbar behaviour when `<body>` isn't on its own line; add tests for this

### DIFF
--- a/.github/workflows/test_navbar_script.yml
+++ b/.github/workflows/test_navbar_script.yml
@@ -1,0 +1,40 @@
+# This workflow runs the insert_navbar script on several test HTML inputs,
+# making sure that the output is as expected.
+
+name: Test Navbar Script
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test-html-diff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Copy script to GHA scratch directory
+        run: cp DocsNav/scripts/insert_navbar.sh .github/workflows/test_navbar_script
+
+      - name: Compare all test inputs against out.html
+        working-directory: .github/workflows/test_navbar_script
+        run: |
+          # Make script executable
+          chmod +x ./insert_navbar.sh
+          # Run script on all files in `ins_html` directory
+          ./insert_navbar.sh ./ins_html ./test_navbar.html
+          # Expected output
+          OUT="expected_out.html"
+          # Check if all files in `ins_html` match the expected output
+          for file in ins_html/*; do
+            if diff <(tr -d '[:space:]' < "$file") <(tr -d '[:space:]' < $OUT); then
+              echo "✅ $file matches $OUT (ignoring whitespace)"
+            else
+              echo "❌ $file differs from $OUT"
+              exit 1  # Fail the job if any file is different
+            fi
+          done

--- a/.github/workflows/test_navbar_script/expected_out.html
+++ b/.github/workflows/test_navbar_script/expected_out.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <p>This is a navbar!</p>
+        <h1>Test 1</h1>
+        <p>Test 1</p>
+    </body>
+</html>

--- a/.github/workflows/test_navbar_script/ins_html/test1_in.html
+++ b/.github/workflows/test_navbar_script/ins_html/test1_in.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        <h1>Test 1</h1>
+        <p>Test 1</p>
+    </body>
+</html>

--- a/.github/workflows/test_navbar_script/ins_html/test2_in.html
+++ b/.github/workflows/test_navbar_script/ins_html/test2_in.html
@@ -1,0 +1,4 @@
+<html>
+    <body><h1>Test 1</h1><p>Test 1</p>
+    </body>
+</html>

--- a/.github/workflows/test_navbar_script/ins_html/test3_in.html
+++ b/.github/workflows/test_navbar_script/ins_html/test3_in.html
@@ -1,0 +1,5 @@
+<html><body>
+    <h1>Test 1</h1>
+    <p>Test 1</p>
+</body>
+</html>

--- a/.github/workflows/test_navbar_script/ins_html/test4_in.html
+++ b/.github/workflows/test_navbar_script/ins_html/test4_in.html
@@ -1,0 +1,2 @@
+<html><body><h1>Test 1</h1><p>Test 1</p>
+</body></html>

--- a/.github/workflows/test_navbar_script/test_navbar.html
+++ b/.github/workflows/test_navbar_script/test_navbar.html
@@ -1,0 +1,1 @@
+<p>This is a navbar!</p>

--- a/DocsNav/scripts/insert_navbar.sh
+++ b/DocsNav/scripts/insert_navbar.sh
@@ -84,9 +84,7 @@ find "$HTML_DIR" -type f -name "*.html" | while read -r file; do
     # Insert the new navbar right after the first <body> tag using awk
     awk -v nav="$NAVBAR_HTML" '
     /<body>/ {
-        print $0
-        print nav
-        next
+        sub(/(<body[^>]*>)/, "&\n" nav);
     }
     { print }
     ' "$file" > temp && mv temp "$file"

--- a/DocsNav/scripts/insert_navbar.sh
+++ b/DocsNav/scripts/insert_navbar.sh
@@ -83,7 +83,7 @@ find "$HTML_DIR" -type f -name "*.html" | while read -r file; do
 
     # Insert the new navbar right after the first <body> tag using awk
     awk -v nav="$NAVBAR_HTML" '
-    /<body>/ {
+    /<body[^>]*>/ {
         sub(/(<body[^>]*>)/, "&\n" nav);
     }
     { print }


### PR DESCRIPTION
The current navbar script searches for lines with `<body>` and inserts the navbar after those lines. This is great when `<body>` is on its own line, but fails when there's stuff that follows it on the same line (https://github.com/TuringLang/TuringBenchmarking.jl/issues/39).

This PR also adds some tests to make sure that it behaves correctly when `<body>` is preceded / followed by other HTML on the same line.
