### PR TITLE
DocsDocumenter - added dirname in deploydocs()

### DIFF
--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Whether to deploy the docs to the gh-pages branch'
     required: false
     default: 'true'
+  dirname:
+    description: 'Subdirectory in gh-pages where the documentation should be deployed'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -84,7 +88,7 @@ runs:
       # Also, `root` must be an absolute path (hence the call to `pwd()`)
       run: |
         using Documenter
-        deploydocs(; root=pwd(), repo="github.com/${{ github.repository }}.git", push_preview=true)
+        deploydocs(; root=pwd(), repo="github.com/${{ github.repository }}.git", dirname="${{ inputs.dirname }}", push_preview=true)
       env:
         GITHUB_TOKEN: ${{ github.token }}
         JULIA_DEBUG: Documenter

--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Path to the built HTML documentation'
     required: false
     default: 'docs/build'
+  dirname:
+    description: 'Subdirectory in gh-pages where the documentation should be deployed'
+    required: false
+    default: ''
   exclude-paths:
     # GitHub Actions doesn't allow array inputs, so the most robust way to
     # handle this is to use a JSON string. DocsNav then parses this using jq.
@@ -29,10 +33,6 @@ inputs:
     description: 'Whether to deploy the docs to the gh-pages branch'
     required: false
     default: 'true'
-  dirname:
-    description: 'Subdirectory in gh-pages where the documentation should be deployed'
-    required: false
-    default: ''
 
 runs:
   using: "composite"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If your `docs/make.jl` file contains a call to `deploydocs()`, it is not a big d
 | `doc-path` | Path to the documentation root | `docs` (following Documenter.jl conventions) |
 | `doc-make-path` | Path to the `make.jl` file | `docs/make.jl` (following Documenter.jl conventions) |
 | `doc-build-path` | Path to the built HTML documentation | `docs/build` (following Documenter.jl conventions) |
+| `dirname` | Subdirectory in gh-pages where the documentation should be deployed | `""` |
 | `julia-version` | Julia version to use | `'1'` |
 | `exclude-paths` | JSON array of filepath patterns to exclude from navbar insertion | `"[]"` |
 | `deploy` | Whether to deploy to the `gh-pages` branch or not | `true` |


### PR DESCRIPTION
We are merging `GeneralisedFilters.jl` and `SSMProblems.jl`, so to deploy documentation of both packages in their respective directories, we need `dirname` parameter!

https://github.com/TuringLang/GeneralisedFilters.jl/pull/29