### PR TITLE
DocsDocumenter: added pkg-path parameter

### DIFF
--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -7,6 +7,11 @@ inputs:
     description: 'Julia version to use'
     required: false
     default: '1'
+  # Specify the package root for Pkg.develop
+  pkg-path:
+    description: 'Path to the package root. If empty, defaults to the current working directory.'
+    required: false
+    default: ''
   doc-path:
     description: 'Path to the Documenter.jl source folder'
     required: false
@@ -52,7 +57,14 @@ runs:
       shell: julia --color=yes --project=${{ inputs.doc-path }} {0}
       run: |
         using Pkg
-        Pkg.develop(PackageSpec(path=pwd()))
+        pkg_path = "{{ inputs.pkg-path }}"
+        if pkg_path == ""
+          # Fallback: assume the package is in the current working directory
+          Pkg.develop(PackageSpec(path=pwd()))
+        else
+          # Use the provided package root
+          Pkg.develop(PackageSpec(path=pkg_path))
+        end
         Pkg.instantiate()
 
     - name: Build docs

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If your `docs/make.jl` file contains a call to `deploydocs()`, it is not a big d
 
 | Parameter | Description | Default |
 | --- | --- | --- |
+| `pkg-path` | Path to the package root. If empty, defaults to the current working directory. | `""` |
 | `doc-path` | Path to the documentation root | `docs` (following Documenter.jl conventions) |
 | `doc-make-path` | Path to the `make.jl` file | `docs/make.jl` (following Documenter.jl conventions) |
 | `doc-build-path` | Path to the built HTML documentation | `docs/build` (following Documenter.jl conventions) |


### PR DESCRIPTION
This gives error in case of nested packages:
```
  using Pkg
  Pkg.develop(PackageSpec(path=pwd()))
  Pkg.instantiate()
```

Error:
```
ERROR: LoadError: could not find project file (Project.toml or JuliaProject.toml) in package at `/home/runner/work/Package.jl/Package.jl` maybe `subdir` needs to be specified
```