### PR TITLE
Modify docs builder to allow for multi-package repos

### DIFF
--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -13,9 +13,9 @@ inputs:
     required: false
     default: ''
   additional_pkg_paths:
-    description: 'JSON array of additional package paths to be dev-ed alongside the main package. For multi-package repos.'
+    description: 'Additional package paths to be dev-ed alongside the main package (one path per line). For multi-package repos.'
     required: false
-    default: '[]'
+    default: ''
   doc-path:
     description: 'Path to the Documenter.jl source folder'
     required: false
@@ -64,7 +64,6 @@ runs:
         INPUT_ADDITIONAL_PKG_PATHS: ${{ inputs.additional_pkg_paths }}
       run: |
         using Pkg
-        using JSON
 
         # Main package development
         pkg_path = ENV["INPUT_PKG_PATH"]
@@ -76,12 +75,10 @@ runs:
 
         # Additional packages development (for multi-package repos)
         additional_pkg_paths_json = ENV["INPUT_ADDITIONAL_PKG_PATHS"]
-        if additional_pkg_paths_json != "[]"
-          additional_pkg_paths = JSON.parse(additional_pkg_paths_json)
-          for path in additional_pkg_paths
-            println("Developing additional package from: ", path)
-            Pkg.develop(PackageSpec(path=path))
-          end
+        for path in split(additional_pkg_paths, "\n")
+          path = strip(path)
+          println("Developing additional package from: ", path)
+          Pkg.develop(PackageSpec(path=path))
         end
 
         Pkg.instantiate()

--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Path to the package root. If empty, defaults to the current working directory.'
     required: false
     default: ''
+  additional_pkg_paths:
+    description: 'JSON array of additional package paths to be dev-ed alongside the main package. For multi-package repos.'
+    required: false
+    default: '[]'
   doc-path:
     description: 'Path to the Documenter.jl source folder'
     required: false
@@ -40,7 +44,7 @@ inputs:
     default: 'true'
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -57,14 +61,29 @@ runs:
       shell: julia --color=yes --project=${{ inputs.doc-path }} {0}
       env:
         INPUT_PKG_PATH: ${{ inputs.pkg_path }}
+        INPUT_ADDITIONAL_PKG_PATHS: ${{ inputs.additional_pkg_paths }}
       run: |
         using Pkg
+        using JSON
+
+        # Main package development
         pkg_path = ENV["INPUT_PKG_PATH"]
         if pkg_path == ""
           Pkg.develop(PackageSpec(path=pwd()))
         else
           Pkg.develop(PackageSpec(path=pkg_path))
         end
+
+        # Additional packages development (for multi-package repos)
+        additional_pkg_paths_json = ENV["INPUT_ADDITIONAL_PKG_PATHS"]
+        if additional_pkg_paths_json != "[]"
+          additional_pkg_paths = JSON.parse(additional_pkg_paths_json)
+          for path in additional_pkg_paths
+            println("Developing additional package from: ", path)
+            Pkg.develop(PackageSpec(path=path))
+          end
+        end
+
         Pkg.instantiate()
 
     - name: Build docs

--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ If your `docs/make.jl` file contains a call to `deploydocs()`, it is not a big d
 
 ### Parameters
 
-| Parameter | Description | Default |
-| --- | --- | --- |
-| `pkg_path` | Path to the package root. If empty, defaults to the current working directory. | `""` |
-| `doc-path` | Path to the documentation root | `docs` (following Documenter.jl conventions) |
-| `doc-make-path` | Path to the `make.jl` file | `docs/make.jl` (following Documenter.jl conventions) |
-| `doc-build-path` | Path to the built HTML documentation | `docs/build` (following Documenter.jl conventions) |
-| `dirname` | Subdirectory in gh-pages where the documentation should be deployed | `""` |
-| `julia-version` | Julia version to use | `'1'` |
-| `exclude-paths` | JSON array of filepath patterns to exclude from navbar insertion | `"[]"` |
-| `deploy` | Whether to deploy to the `gh-pages` branch or not | `true` |
+| Parameter              | Description                                                                                                    | Default                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `pkg_path`             | Path to the package root. If empty, defaults to the current working directory.                                 | `""`                                                 |
+| `additional_pkg_paths` | Additional package paths to be dev-ed alongside the main package (one path per line). For multi-package repos. | `""`                                                 |
+| `doc-path`             | Path to the documentation root                                                                                 | `docs` (following Documenter.jl conventions)         |
+| `doc-make-path`        | Path to the `make.jl` file                                                                                     | `docs/make.jl` (following Documenter.jl conventions) |
+| `doc-build-path`       | Path to the built HTML documentation                                                                           | `docs/build` (following Documenter.jl conventions)   |
+| `dirname`              | Subdirectory in gh-pages where the documentation should be deployed                                            | `""`                                                 |
+| `julia-version`        | Julia version to use                                                                                           | `'1'`                                                |
+| `exclude-paths`        | JSON array of filepath patterns to exclude from navbar insertion                                               | `"[]"`                                               |
+| `deploy`               | Whether to deploy to the `gh-pages` branch or not                                                              | `true`                                               |
 
 ### Example usage
 


### PR DESCRIPTION
This change allows additional paths to be passed into the action which will then be dev-ed, allowing for the building of multi-package repos.

Specifically, this will allow the docs for GeneralisedFilters.jl, which depends on SSMProblems.jl, to be built.

I'm not sure how to properly test this code, but it looks like it should behave the same when the default input is used.

