### PR TITLE
DocsNav: Added deprecation label in TuringBenchmarking

### DIFF
--- a/DocsNav/scripts/TuringNavbar.html
+++ b/DocsNav/scripts/TuringNavbar.html
@@ -33,6 +33,8 @@
         --item-color: rgb(165, 165, 165);
         --primary-bg: #073c44;
         --hover-color: #8faad2;
+        --deprecated-bg: #ff4d4d;
+        --deprecated-text: white;
     }
 
     .ext-navigation {
@@ -130,6 +132,8 @@
 
     .ext-dropdown ul li {
         text-align: left;
+        display: flex;
+        align-items: center;
     }
 
     .navbar-sub-item {
@@ -151,6 +155,16 @@
     .ext-dropdown-item-heading {
         color: var(--heading-color);
         text-align: center;
+    }
+
+    .deprecated-badge {
+        background-color: var(--deprecated-bg);
+        color: var(--deprecated-text);
+        font-size: 0.75rem;
+        padding: 0.125rem 0.375rem;
+        border-radius: 3px;
+        margin-left: 0.5rem;
+        line-height: 1;
     }
 
     /* Responsive styling */
@@ -210,6 +224,7 @@
 
         .ext-dropdown ul li {
             text-align: center;
+            /* justify-content: center; */
         }
 
         .ext-dropdown ul a li {
@@ -327,7 +342,8 @@
                 </ul>
                 <ul>
                     <li class="ext-dropdown-item-heading ext-navbar-item-single">
-                        <a href="https://turinglang.org/TuringBenchmarking.jl/">TuringBenchmarking</a>
+                        <a href="https://turinglang.org/Deprecated/TuringBenchmarking/">TuringBenchmarking</a>
+                        <span class="deprecated-badge">Deprecated</span>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Looks like this:
![image](https://github.com/user-attachments/assets/cd5dbbd6-9013-42c6-ba86-e9c90164a466)

Closes https://github.com/TuringLang/turinglang.github.io/issues/122