### PR TITLE
DocsDocumenter: Skip commenting preview URL in PR from forked repos

### DIFF
--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -138,7 +138,7 @@ runs:
         body-includes: "docs-preview-url-${{ github.event.repository.name }}${{ env.DOCS_SUBDIR }}"
 
     - name: Create or Update Documentation Preview Comment
-      if: ${{ github.event_name == 'pull_request' && inputs.deploy == 'true' }}
+      if: ${{ github.event_name == 'pull_request' && inputs.deploy == 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Avoid using [`pull_request_target`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) event for security reasons, if in future we ever decide to comment on PRs from forked repos then this method may help: https://stackoverflow.com/a/71683208/21356212

Original Source: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
