### PR TITLE
Add DocsDocumenter preview outputs

### DIFF
--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -54,6 +54,18 @@ inputs:
     description: 'Whether to deploy the docs to the gh-pages branch'
     required: false
     default: 'true'
+  post-preview-comment:
+    description: 'Whether to post a pull request preview comment after deployment'
+    required: false
+    default: 'true'
+
+outputs:
+  preview_url:
+    description: 'Preview URL for pull request docs previews'
+    value: ${{ steps.docs_preview_metadata.outputs.preview_url }}
+  preview_comment_body:
+    description: 'Comment body that would be posted for the pull request docs preview'
+    value: ${{ steps.docs_preview_metadata.outputs.preview_comment_body }}
 
 runs:
   using: 'composite'
@@ -136,27 +148,35 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         JULIA_DEBUG: Documenter
         
-    - name: Set docs subdirectory path
+    - name: Compute docs preview metadata
       if: ${{ github.event_name == 'pull_request' && inputs.deploy == 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+      id: docs_preview_metadata
       shell: bash
-      run: echo "DOCS_SUBDIR=${{ inputs.dirname != '' && format('/{0}', inputs.dirname) || '' }}" >> $GITHUB_ENV
+      run: |
+        docs_subdir="${{ inputs.dirname != '' && format('/{0}', inputs.dirname) || '' }}"
+        preview_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}${docs_subdir}/previews/PR${{ github.event.pull_request.number }}/"
+        {
+          echo "docs_subdir=${docs_subdir}"
+          echo "preview_url=${preview_url}"
+          echo "preview_comment_body<<EOF"
+          echo "<!-- docs-preview-url-${{ github.event.repository.name }}${docs_subdir} -->"
+          echo "${{ github.event.repository.name }}${docs_subdir} documentation for PR #${{ github.event.pull_request.number }} is available at:"
+          echo "${preview_url}"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Check for Existing Docs Preview Comment
-      if: ${{ github.event_name == 'pull_request' && inputs.deploy == 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+      if: ${{ github.event_name == 'pull_request' && inputs.deploy == 'true' && inputs.post-preview-comment == 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
       uses: peter-evans/find-comment@v3
       id: existing_docs_preview_comment
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: github-actions[bot]
-        body-includes: "docs-preview-url-${{ github.event.repository.name }}${{ env.DOCS_SUBDIR }}"
+        body-includes: "docs-preview-url-${{ github.event.repository.name }}${{ steps.docs_preview_metadata.outputs.docs_subdir }}"
 
     - name: Create Documentation Preview Comment (if needed)
-      if: ${{ steps.existing_docs_preview_comment.outputs.comment-id == '' && github.event_name == 'pull_request' && inputs.deploy == 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+      if: ${{ steps.existing_docs_preview_comment.outputs.comment-id == '' && github.event_name == 'pull_request' && inputs.deploy == 'true' && inputs.post-preview-comment == 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          <!-- docs-preview-url-${{ github.event.repository.name }}${{ env.DOCS_SUBDIR }} -->
-          ${{ github.event.repository.name }}${{ env.DOCS_SUBDIR }} documentation for PR #${{ github.event.pull_request.number }} is available at:
-          https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}${{ env.DOCS_SUBDIR }}/previews/PR${{ github.event.pull_request.number }}/
-          
+        body: ${{ steps.docs_preview_metadata.outputs.preview_comment_body }}

--- a/README.md
+++ b/README.md
@@ -30,9 +30,19 @@ If your `docs/make.jl` file contains a call to `deploydocs()`, it is not a big d
 | `doc-make-path`        | Path to the `make.jl` file                                                                                     | `docs/make.jl` (following Documenter.jl conventions) |
 | `doc-build-path`       | Path to the built HTML documentation                                                                           | `docs/build` (following Documenter.jl conventions)   |
 | `dirname`              | Subdirectory in gh-pages where the documentation should be deployed                                            | `""`                                                 |
+| `tag_prefix`           | Prefix for the git tag used for versioning, useful for monorepo packages                                       | `""`                                                 |
+| `navbar-url`           | URL or local path of the navbar HTML to insert                                                                 | `""`                                                 |
 | `julia-version`        | Julia version to use                                                                                           | `'1'`                                                |
 | `exclude-paths`        | JSON array of filepath patterns to exclude from navbar insertion                                               | `"[]"`                                               |
 | `deploy`               | Whether to deploy to the `gh-pages` branch or not                                                              | `true`                                               |
+| `post-preview-comment` | Whether to post the sticky pull request preview comment after deployment                                       | `true`                                               |
+
+### Outputs
+
+| Output | Description |
+| --- | --- |
+| `preview_url` | Preview URL for pull request docs previews |
+| `preview_comment_body` | Comment body used for the pull request docs preview |
 
 ### Example usage
 


### PR DESCRIPTION
## Summary
Add DocsDocumenter outputs for docs preview metadata and allow callers to disable the sticky preview comment.

## Changes
- add a `post-preview-comment` input
- expose `preview_url` and `preview_comment_body` outputs
- compute preview metadata once and reuse it for both outputs and optional comment posting

This is helpful for https://github.com/chalk-lab/Mooncake.jl/pull/1095