### PR TITLE
Fix SyncPRSummary action bot comments scanning and redundant API calls

### DIFF
--- a/SyncPRSummary/action.yml
+++ b/SyncPRSummary/action.yml
@@ -33,6 +33,7 @@ runs:
             },
             {
               key:      "perf",
+              marker:   "<!-- perf-results -->",
               title:    "Performance",
               input:    (process.env.INPUT_PERF_CONTENT ?? "").trim(),
               fallback: "_Pending. No performance results available yet._",
@@ -72,16 +73,36 @@ runs:
 
           const managedBody = managedComment?.body ?? "";
 
-          const resolvedSections = SECTIONS.map(({ key, title, input, fallback }) => ({
+          const latestByMarker = new Map();
+          for (const comment of allComments) {
+            const body = comment.body || "";
+            const user = comment.user?.login;
+            const app  = comment.performed_via_github_app?.slug;
+            const isBot = user === "github-actions[bot]" || app === "github-actions";
+            if (!isBot) continue;
+
+            for (const { marker, title } of SECTIONS) {
+              if (!marker) continue;
+              if (!body.startsWith(marker)) continue;
+              const content = body.slice(marker.length).trim();
+              if (content) latestByMarker.set(marker, content);
+            }
+          }
+
+          const resolvedSections = SECTIONS.map(({ key, marker, title, input, fallback }) => ({
             key,
             title,
-            content: input || readSection(managedBody, key) || fallback,
+            content: input || latestByMarker.get(marker) || readSection(managedBody, key) || fallback,
           }));
 
           const newBody = buildBody(resolvedSections);
 
           if (managedComment) {
-            await github.rest.issues.updateComment({ owner, repo, comment_id: managedComment.id, body: newBody });
+            if (managedComment.body !== newBody) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: managedComment.id, body: newBody });
+            } else {
+              core.info("PR summary already up to date.");
+            }
           } else {
             await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: newBody });
           }


### PR DESCRIPTION
This commit restores the functionality in the `SyncPRSummary` action to scan other bot comments for specific markers (like `<!-- perf-results -->`) when the input is empty. This fallback was accidentally lost during the PR #27 refactor but is needed for workflows that don't pass explicit inputs.

Additionally, this commit re-introduces the equality check before making `updateComment` API calls to prevent redundant updates when the content hasn't changed.

---
*PR created automatically by Jules for task [3439081147760001566](https://jules.google.com/task/3439081147760001566) started by @shravanngoswamii*