### PR TITLE
Update Format action: version/paths inputs, caching, explicit diff check

### DIFF
--- a/Format/action.yml
+++ b/Format/action.yml
@@ -16,13 +16,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: julia-actions/setup-julia@v2
       with:
         version: 1
 
-    - uses: julia-actions/cache@v2
+    - uses: julia-actions/cache@v3
 
     - name: Install JuliaFormatter
       shell: julia --color=yes {0}

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -3,15 +3,15 @@ author: 'TuringLang'
 description: 'Run JuliaFormatter on the repository'
 inputs:
   version:
-    description: 'Version of JuliaFormatter.jl. Examples: 2, 2.0, 2.1.0'
-    default: '2'
+    description: 'Version of JuliaFormatter.jl. Examples: 1, 1.0, 1.0.44'
+    default: '1'
   paths:
     description: 'A comma-separated list of paths (folders or files) to be formatted'
     default: '.'
   suggest-changes:
-    description: 'Whether to suggest changes on PRs. Defaults to true'
+    description: 'Whether to suggest changes on PRs. Defaults to false'
     required: false
-    default: 'true'
+    default: 'false'
 
 runs:
   using: "composite"
@@ -28,8 +28,8 @@ runs:
       shell: julia --color=yes {0}
       run: |
         import Pkg
-        _version_original = get(ENV, "jf-version", "2")
-        version = convert(String, strip(_version_original))::String
+        _version_original = get(ENV, "jf-version", "1")
+        version = convert(String, strip(_version_original))
         if isempty(version)
             error("The version input cannot be empty")
         end

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -2,6 +2,12 @@ name: 'Format'
 author: 'TuringLang'
 description: 'Run JuliaFormatter on the repository'
 inputs:
+  version:
+    description: 'Version of JuliaFormatter.jl. Examples: 2, 2.0, 2.1.0'
+    default: '2'
+  paths:
+    description: 'A comma-separated list of paths (folders or files) to be formatted'
+    default: '.'
   suggest-changes:
     description: 'Whether to suggest changes on PRs. Defaults to true'
     required: false
@@ -16,13 +22,34 @@ runs:
       with:
         version: 1
 
-    - name: Format code
-      run: |
-        using Pkg
-        Pkg.add(; name="JuliaFormatter", version="1")
-        using JuliaFormatter
-        format("."; verbose=true)
+    - uses: julia-actions/cache@v2
+
+    - name: Install JuliaFormatter
       shell: julia --color=yes {0}
+      run: |
+        import Pkg
+        _version_original = get(ENV, "jf-version", "2")
+        version = convert(String, strip(_version_original))::String
+        if isempty(version)
+            error("The version input cannot be empty")
+        end
+        p = Pkg.PackageSpec(
+            name = "JuliaFormatter",
+            uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899",
+            version = version,
+        )
+        Pkg.add(p)
+      env:
+        jf-version: ${{ inputs.version }}
+
+    - name: Format code
+      shell: julia --color=yes {0}
+      run: |
+        import JuliaFormatter
+        paths = strip.(split(get(ENV, "jf-paths", "."), ","))
+        JuliaFormatter.format(paths; verbose=true)
+      env:
+        jf-paths: ${{ inputs.paths }}
 
     - name: Get JuliaFormatter version
       id: get-version
@@ -32,8 +59,18 @@ runs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
       shell: bash
 
+    - name: Check for formatting errors
+      shell: bash
+      run: |
+        output=$(git diff --name-only)
+        if [ "$output" != "" ]; then
+            >&2 echo "Some files have not been formatted !!!"
+            echo "$output"
+            exit 1
+        fi
+
     - uses: reviewdog/action-suggester@v1.22
-      if: ${{ inputs.suggest-changes && github.event_name == 'pull_request' }}
+      if: ${{ failure() && inputs.suggest-changes == 'true' && github.event_name == 'pull_request' }}
       with:
         tool_name: JuliaFormatter v${{ steps.get-version.outputs.version }}
-        fail_level: any
+        fail_level: error

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Run JuliaFormatter on the content in the repository.
 
 | Parameter | Description | Default |
 | --- | --- | --- |
-| `version` | Version of JuliaFormatter.jl (e.g. `2`, `2.0`, `2.1.0`) | `"2"` |
+| `version` | Version of JuliaFormatter.jl (e.g. `1`, `1.0`, `1.0.44`) | `"1"` |
 | `paths` | Comma-separated list of paths (folders or files) to format | `"."` |
-| `suggest-changes` | Whether to comment on PRs with suggested changes | `"true"` |
+| `suggest-changes` | Whether to comment on PRs with suggested changes | `"false"` |
 
 ### Example usage
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Run JuliaFormatter on the content in the repository.
 
 | Parameter | Description | Default |
 | --- | --- | --- |
+| `version` | Version of JuliaFormatter.jl (e.g. `2`, `2.0`, `2.1.0`) | `"2"` |
+| `paths` | Comma-separated list of paths (folders or files) to format | `"."` |
 | `suggest-changes` | Whether to comment on PRs with suggested changes | `"true"` |
 
 ### Example usage


### PR DESCRIPTION
- Keep default JuliaFormatter version to `1`
- Adds `version` and `paths` inputs
- Adds `julia-actions/cache@v2` for faster runs
- Splits install and format into separate steps
- Adds explicit `git diff` check that fails before reaching reviewdog
- Fixes reviewdog `if` condition and sets `fail_level: error`

Generated by [Claude Code](https://claude.ai/code)