### PR TITLE
Add Runic.jl formatter support

### DIFF
--- a/Format/action.yml
+++ b/Format/action.yml
@@ -57,11 +57,6 @@ runs:
         jf-paths: ${{ inputs.paths }}
 
     # --- Runic ---
-    - name: Warn if paths used with Runic
-      if: ${{ inputs.formatter == 'runic' && inputs.paths != '.' }}
-      shell: bash
-      run: echo "::warning::The 'paths' input is ignored when using Runic. Runic always checks all tracked .jl files via git ls-files."
-
     - name: Install Runic
       if: ${{ inputs.formatter == 'runic' }}
       shell: julia --color=yes {0}
@@ -85,12 +80,10 @@ runs:
       shell: julia --color=yes {0}
       run: |
         import Runic
-        julia_files = readlines(`git ls-files -- "*.jl"`)
-        if isempty(julia_files)
-            println("Runic: no .jl files tracked, skipping.")
-        else
-            Runic.main(append!(["--inplace"], julia_files))
-        end
+        paths = strip.(split(get(ENV, "runic-paths", "."), ","))
+        Runic.main(append!(["--inplace"], paths))
+      env:
+        runic-paths: ${{ inputs.paths }}
 
     # --- Shared ---
     - name: Get formatter version

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -116,4 +116,3 @@ runs:
       with:
         tool_name: "${{ inputs.formatter == 'juliaformatter' && 'JuliaFormatter' || 'Runic' }} v${{ steps.get-version.outputs.version }}"
         fail_level: error
-        filter_mode: nofilter

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -116,3 +116,4 @@ runs:
       with:
         tool_name: "${{ inputs.formatter == 'juliaformatter' && 'JuliaFormatter' || 'Runic' }} v${{ steps.get-version.outputs.version }}"
         fail_level: error
+        filter_mode: nofilter

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -102,7 +102,6 @@ runs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Check for formatting errors
-      id: check-formatting
       shell: bash
       run: |
         output=$(git diff --name-only)
@@ -113,8 +112,7 @@ runs:
         fi
 
     - uses: reviewdog/action-suggester@v1.22
-      if: ${{ steps.check-formatting.outcome == 'failure' && inputs.suggest-changes == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ failure() && inputs.suggest-changes == 'true' && github.event_name == 'pull_request' }}
       with:
         tool_name: "${{ inputs.formatter == 'juliaformatter' && 'JuliaFormatter' || 'Runic' }} v${{ steps.get-version.outputs.version }}"
         fail_level: error
-        github_token: ${{ github.token }}

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -57,6 +57,11 @@ runs:
         jf-paths: ${{ inputs.paths }}
 
     # --- Runic ---
+    - name: Warn if paths used with Runic
+      if: ${{ inputs.formatter == 'runic' && inputs.paths != '.' }}
+      shell: bash
+      run: echo "::warning::The 'paths' input is ignored when using Runic. Runic always checks all tracked .jl files via git ls-files."
+
     - name: Install Runic
       if: ${{ inputs.formatter == 'runic' }}
       shell: julia --color=yes {0}

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -1,12 +1,15 @@
 name: 'Format'
 author: 'TuringLang'
-description: 'Run JuliaFormatter on the repository'
+description: 'Run a Julia code formatter on the repository'
 inputs:
+  formatter:
+    description: 'Formatter to use: juliaformatter or runic'
+    default: 'juliaformatter'
   version:
-    description: 'Version of JuliaFormatter.jl. Examples: 1, 1.0, 1.0.44'
+    description: 'Version of the formatter (JuliaFormatter: 1, 1.0, 1.0.44 | Runic: 1, 1.0, 1.0.1)'
     default: '1'
   paths:
-    description: 'A comma-separated list of paths (folders or files) to be formatted'
+    description: 'Comma-separated list of paths to format (JuliaFormatter only; Runic checks all tracked .jl files)'
     default: '.'
   suggest-changes:
     description: 'Whether to suggest changes on PRs. Defaults to false'
@@ -24,7 +27,9 @@ runs:
 
     - uses: julia-actions/cache@v3
 
+    # --- JuliaFormatter ---
     - name: Install JuliaFormatter
+      if: ${{ inputs.formatter == 'juliaformatter' }}
       shell: julia --color=yes {0}
       run: |
         import Pkg
@@ -33,16 +38,16 @@ runs:
         if isempty(version)
             error("The version input cannot be empty")
         end
-        p = Pkg.PackageSpec(
+        Pkg.add(Pkg.PackageSpec(
             name = "JuliaFormatter",
             uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899",
             version = version,
-        )
-        Pkg.add(p)
+        ))
       env:
         jf-version: ${{ inputs.version }}
 
-    - name: Format code
+    - name: Format code (JuliaFormatter)
+      if: ${{ inputs.formatter == 'juliaformatter' }}
       shell: julia --color=yes {0}
       run: |
         import JuliaFormatter
@@ -51,13 +56,45 @@ runs:
       env:
         jf-paths: ${{ inputs.paths }}
 
-    - name: Get JuliaFormatter version
-      id: get-version
+    # --- Runic ---
+    - name: Install Runic
+      if: ${{ inputs.formatter == 'runic' }}
+      shell: julia --color=yes {0}
       run: |
-        VERSION=$(julia -e 'using Pkg; Pkg.status("JuliaFormatter")' | grep JuliaFormatter | sed 's/.* JuliaFormatter v//')
-        echo "JuliaFormatter version: $VERSION"
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        import Pkg
+        _version_original = get(ENV, "runic-version", "1")
+        version = convert(String, strip(_version_original))
+        if isempty(version)
+            error("The version input cannot be empty")
+        end
+        Pkg.add(Pkg.PackageSpec(
+            name = "Runic",
+            uuid = "62bfec6d-59d7-401d-8490-b29ee721c001",
+            version = version,
+        ))
+      env:
+        runic-version: ${{ inputs.version }}
+
+    - name: Format code (Runic)
+      if: ${{ inputs.formatter == 'runic' }}
+      shell: julia --color=yes {0}
+      run: |
+        import Runic
+        julia_files = readlines(`git ls-files -- "*.jl"`)
+        if isempty(julia_files)
+            println("Runic: no .jl files tracked, skipping.")
+        else
+            Runic.main(append!(["--inplace"], julia_files))
+        end
+
+    # --- Shared ---
+    - name: Get formatter version
+      id: get-version
       shell: bash
+      run: |
+        if [ "${{ inputs.formatter }}" = "juliaformatter" ]; then PKG="JuliaFormatter"; else PKG="Runic"; fi
+        VERSION=$(julia -e "using Pkg; Pkg.status(\"$PKG\")" | grep "$PKG" | sed "s/.* $PKG v//")
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Check for formatting errors
       shell: bash
@@ -72,5 +109,5 @@ runs:
     - uses: reviewdog/action-suggester@v1.22
       if: ${{ failure() && inputs.suggest-changes == 'true' && github.event_name == 'pull_request' }}
       with:
-        tool_name: JuliaFormatter v${{ steps.get-version.outputs.version }}
+        tool_name: "${{ inputs.formatter == 'juliaformatter' && 'JuliaFormatter' || 'Runic' }} v${{ steps.get-version.outputs.version }}"
         fail_level: error

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Version of the formatter (JuliaFormatter: 1, 1.0, 1.0.44 | Runic: 1, 1.0, 1.0.1)'
     default: '1'
   paths:
-    description: 'Comma-separated list of paths to format (JuliaFormatter only; Runic checks all tracked .jl files)'
+    description: 'Comma-separated list of paths (folders or files) to format'
     default: '.'
   suggest-changes:
     description: 'Whether to suggest changes on PRs. Defaults to false'

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -102,6 +102,7 @@ runs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Check for formatting errors
+      id: check-formatting
       shell: bash
       run: |
         output=$(git diff --name-only)
@@ -112,7 +113,8 @@ runs:
         fi
 
     - uses: reviewdog/action-suggester@v1.22
-      if: ${{ failure() && inputs.suggest-changes == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ steps.check-formatting.outcome == 'failure' && inputs.suggest-changes == 'true' && github.event_name == 'pull_request' }}
       with:
         tool_name: "${{ inputs.formatter == 'juliaformatter' && 'JuliaFormatter' || 'Runic' }} v${{ steps.get-version.outputs.version }}"
         fail_level: error
+        github_token: ${{ github.token }}

--- a/Format/action.yml
+++ b/Format/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Version of the formatter (JuliaFormatter: 1, 1.0, 1.0.44 | Runic: 1, 1.0, 1.0.1)'
     default: '1'
   paths:
-    description: 'Comma-separated list of paths (folders or files) to format'
+    description: 'A comma-separated list of paths (folders or files) to be formatted'
     default: '.'
   suggest-changes:
     description: 'Whether to suggest changes on PRs. Defaults to false'

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Run a Julia code formatter on the content in the repository. Supports [JuliaForm
 | --- | --- | --- |
 | `formatter` | Formatter to use: `juliaformatter` or `runic` | `"juliaformatter"` |
 | `version` | Version of the formatter | `"1"` |
-| `paths` | Comma-separated list of paths to format (JuliaFormatter only) | `"."` |
+| `paths` | Comma-separated list of paths to format (JuliaFormatter only; ignored by Runic, which always checks all tracked `.jl` files — a warning is emitted if set) | `"."` |
 | `suggest-changes` | Whether to comment on PRs with suggested changes | `"false"` |
 
 ### Example usage

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Run a Julia code formatter on the content in the repository. Supports [JuliaForm
 | --- | --- | --- |
 | `formatter` | Formatter to use: `juliaformatter` or `runic` | `"juliaformatter"` |
 | `version` | Version of the formatter | `"1"` |
-| `paths` | Comma-separated list of paths to format (JuliaFormatter only; ignored by Runic, which always checks all tracked `.jl` files — a warning is emitted if set) | `"."` |
+| `paths` | Comma-separated list of paths (folders or files) to format | `"."` |
 | `suggest-changes` | Whether to comment on PRs with suggested changes | `"false"` |
 
 ### Example usage

--- a/README.md
+++ b/README.md
@@ -77,14 +77,15 @@ See [`example_workflows/DocsNav.yml`](https://github.com/TuringLang/actions/blob
 
 ## Format
 
-Run JuliaFormatter on the content in the repository.
+Run a Julia code formatter on the content in the repository. Supports [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) and [Runic.jl](https://github.com/fredrikekre/Runic.jl).
 
 ### Parameters
 
 | Parameter | Description | Default |
 | --- | --- | --- |
-| `version` | Version of JuliaFormatter.jl (e.g. `1`, `1.0`, `1.0.44`) | `"1"` |
-| `paths` | Comma-separated list of paths (folders or files) to format | `"."` |
+| `formatter` | Formatter to use: `juliaformatter` or `runic` | `"juliaformatter"` |
+| `version` | Version of the formatter | `"1"` |
+| `paths` | Comma-separated list of paths to format (JuliaFormatter only) | `"."` |
 | `suggest-changes` | Whether to comment on PRs with suggested changes | `"false"` |
 
 ### Example usage


### PR DESCRIPTION
Adds a `formatter` input (`juliaformatter` | `runic`) so repos can opt into Runic. JuliaFormatter remains the default.

Closes #23 