### PR TITLE
Add DocumenterVitepress support to DocsDocumenter

### DIFF
--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -116,6 +116,14 @@ runs:
     - name: Build docs
       shell: bash
       run: julia --project=${{ inputs.doc-path }} ${{ inputs.doc-make-path }}
+      # `DocumenterVitepress`'s writer calls `Documenter.deploy_folder(...)`
+      # at build time to decide the `bases` it writes to `build/bases.txt`.
+      # `deploy_folder` requires `GITHUB_TOKEN` to be present to recognise
+      # a CI build; without it the writer falls back to `all_ok=false`,
+      # `subfolder=""`, and the later deploy step finds an empty bases list
+      # and skips. Expose the token so PR-preview deploys work end-to-end.
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
 
       # We want to use the same version of DocsNav. In principle we would like
       # to write `uses: TuringLang/actions/DocsNav@${{ github.action_ref }}`,

--- a/DocsDocumenter/action.yml
+++ b/DocsDocumenter/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: 'Whether to deploy the docs to the gh-pages branch'
     required: false
     default: 'true'
+  use-vitepress:
+    description: 'Whether to use DocumenterVitepress.deploydocs() instead of Documenter.deploydocs() for deployment. Requires DocumenterVitepress to be listed in the docs Project.toml.'
+    required: false
+    default: 'false'
   post-preview-comment:
     description: 'Whether to post a pull request preview comment after deployment'
     required: false
@@ -142,8 +146,14 @@ runs:
       # Must pass `root` when `deploydocs()` is run from outside make.jl file
       # Also, `root` must be an absolute path (hence the call to `pwd()`)
       run: |
-        using Documenter
-        deploydocs(; root=pwd(), repo="github.com/${{ github.repository }}.git", dirname="${{ inputs.dirname }}", tag_prefix="${{ inputs.tag_prefix }}", push_preview=true)
+        use_vitepress = "${{ inputs.use-vitepress }}" == "true"
+        if use_vitepress
+            using DocumenterVitepress
+            DocumenterVitepress.deploydocs(; root=pwd(), repo="github.com/${{ github.repository }}.git", dirname="${{ inputs.dirname }}", tag_prefix="${{ inputs.tag_prefix }}", push_preview=true)
+        else
+            using Documenter
+            deploydocs(; root=pwd(), repo="github.com/${{ github.repository }}.git", dirname="${{ inputs.dirname }}", tag_prefix="${{ inputs.tag_prefix }}", push_preview=true)
+        end
       env:
         GITHUB_TOKEN: ${{ github.token }}
         JULIA_DEBUG: Documenter

--- a/DocsNav/scripts/TuringNavbar.html
+++ b/DocsNav/scripts/TuringNavbar.html
@@ -43,6 +43,26 @@
     .VPHome {
         padding-top: var(--navbar-height) !important;
     }
+
+    /* When the rendered site is Vitepress (detected by .VPNavBar being in the
+       DOM), adopt Vitepress's design tokens so the TuringLang navbar tracks
+       the active theme (light/dark, brand colour, body font) and reads as one
+       piece of chrome with the Vitepress nav below it — rather than a stacked
+       second header with its own colour and typography. */
+    html:has(.VPNavBar) {
+        --primary-bg: var(--vp-c-bg);
+        --heading-color: var(--vp-c-text-1);
+        --item-color: var(--vp-c-text-2);
+        --icon-color: var(--vp-c-text-1);
+        --hover-color: var(--vp-c-brand-1);
+        --shadow-color: var(--vp-c-divider);
+        --dropdown-hover-bg: var(--vp-c-default-soft);
+        --font-family: var(--vp-font-family-base);
+    }
+    html:has(.VPNavBar) .ext-navigation {
+        box-shadow: none;
+        border-bottom: 1px solid var(--vp-c-divider);
+    }
     /* End of DocumenterVitepress Tweaks */
 
     /* Color and Font Variables */

--- a/DocsNav/scripts/TuringNavbar.html
+++ b/DocsNav/scripts/TuringNavbar.html
@@ -22,32 +22,18 @@
     }
     /* End of Documenter.jl Tweaks */
 
-    /* DocumenterVitepress CSS Overrides:
-       Vitepress fixes its own nav and sidebar to the top of the viewport,
-       which would overlap the TuringLang navbar inserted just inside <body>.
-       Push the Vitepress-side fixed chrome down by --navbar-height so the
-       two stack cleanly. Only fires when these Vitepress classes are
-       present, so it has no effect on Documenter HTML output. */
-
-    /* `.VPNav` is the outer position:fixed container; its inner `.VPNavBar`
-       is position:relative, so shifting only the outer is correct (shifting
-       both would double-offset and create a gap). */
-    .VPNav {
-        top: var(--navbar-height) !important;
-    }
-    /* Sidebar and mobile sticky local-nav are independently fixed at
-       top:var(--vp-nav-height); add --navbar-height so they clear both
-       the TuringLang navbar and Vitepress's own nav. */
-    .VPSidebar,
-    .VPLocalNav,
-    .VPLocalNavOuterContainer {
-        top: calc(var(--vp-nav-height, 64px) + var(--navbar-height)) !important;
-    }
-    /* Page content already has padding-top to clear Vitepress's nav.
-       Add --navbar-height as a margin (additive) so it also clears
-       the TuringLang navbar above. */
-    .VPContent {
-        margin-top: var(--navbar-height);
+    /* DocumenterVitepress integration:
+       Vitepress's default theme already exposes `--vp-layout-top-height` as
+       the hook for adding banner-style chrome above its own nav. Every
+       layout-sensitive component (`.VPNav` `top`, `.VPContent` `margin`,
+       `.VPSidebar` `top`, `.VPLocalNav` `padding-top`, `.VPDocAside` `top`
+       and TOC `padding-top`) is already authored to add this variable to
+       its own offset, so binding it to the TuringLang navbar height makes
+       Vitepress reflow itself correctly with zero further intervention.
+       (`:has(.VPNavBar)` scopes this to Vitepress builds; Documenter HTML
+       sites are untouched.) */
+    html:has(.VPNavBar) {
+        --vp-layout-top-height: var(--navbar-height);
     }
 
     /* When the rendered site is Vitepress (detected by .VPNavBar being in the

--- a/DocsNav/scripts/TuringNavbar.html
+++ b/DocsNav/scripts/TuringNavbar.html
@@ -22,6 +22,29 @@
     }
     /* End of Documenter.jl Tweaks */
 
+    /* DocumenterVitepress CSS Overrides:
+       Vitepress fixes its own nav and sidebar to the top of the viewport,
+       which would overlap the TuringLang navbar inserted just inside <body>.
+       Push everything Vitepress-side down by --navbar-height so the two stack
+       cleanly. Only fires when these Vitepress classes are present, so it
+       has no effect on Documenter HTML output. */
+    .VPNav,
+    .VPNavBar,
+    .VPLocalNav,
+    .VPLocalNavOuterContainer {
+        top: var(--navbar-height) !important;
+    }
+    .VPSidebar {
+        padding-top: var(--navbar-height) !important;
+    }
+    .VPContent.has-sidebar,
+    .VPContent.is-home,
+    .VPDoc,
+    .VPHome {
+        padding-top: var(--navbar-height) !important;
+    }
+    /* End of DocumenterVitepress Tweaks */
+
     /* Color and Font Variables */
     :root {
         --heading-color: #6c757d;

--- a/DocsNav/scripts/TuringNavbar.html
+++ b/DocsNav/scripts/TuringNavbar.html
@@ -25,23 +25,29 @@
     /* DocumenterVitepress CSS Overrides:
        Vitepress fixes its own nav and sidebar to the top of the viewport,
        which would overlap the TuringLang navbar inserted just inside <body>.
-       Push everything Vitepress-side down by --navbar-height so the two stack
-       cleanly. Only fires when these Vitepress classes are present, so it
-       has no effect on Documenter HTML output. */
-    .VPNav,
-    .VPNavBar,
-    .VPLocalNav,
-    .VPLocalNavOuterContainer {
+       Push the Vitepress-side fixed chrome down by --navbar-height so the
+       two stack cleanly. Only fires when these Vitepress classes are
+       present, so it has no effect on Documenter HTML output. */
+
+    /* `.VPNav` is the outer position:fixed container; its inner `.VPNavBar`
+       is position:relative, so shifting only the outer is correct (shifting
+       both would double-offset and create a gap). */
+    .VPNav {
         top: var(--navbar-height) !important;
     }
-    .VPSidebar {
-        padding-top: var(--navbar-height) !important;
+    /* Sidebar and mobile sticky local-nav are independently fixed at
+       top:var(--vp-nav-height); add --navbar-height so they clear both
+       the TuringLang navbar and Vitepress's own nav. */
+    .VPSidebar,
+    .VPLocalNav,
+    .VPLocalNavOuterContainer {
+        top: calc(var(--vp-nav-height, 64px) + var(--navbar-height)) !important;
     }
-    .VPContent.has-sidebar,
-    .VPContent.is-home,
-    .VPDoc,
-    .VPHome {
-        padding-top: var(--navbar-height) !important;
+    /* Page content already has padding-top to clear Vitepress's nav.
+       Add --navbar-height as a margin (additive) so it also clears
+       the TuringLang navbar above. */
+    .VPContent {
+        margin-top: var(--navbar-height);
     }
 
     /* When the rendered site is Vitepress (detected by .VPNavBar being in the

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If your `docs/make.jl` file contains a call to `deploydocs()`, it is not a big d
 | `julia-version`        | Julia version to use                                                                                           | `'1'`                                                |
 | `exclude-paths`        | JSON array of filepath patterns to exclude from navbar insertion                                               | `"[]"`                                               |
 | `deploy`               | Whether to deploy to the `gh-pages` branch or not                                                              | `true`                                               |
+| `use-vitepress`        | Use `DocumenterVitepress.deploydocs()` instead of `Documenter.deploydocs()`. Requires `DocumenterVitepress` in the docs `Project.toml`. | `false` |
 | `post-preview-comment` | Whether to post the sticky pull request preview comment after deployment                                       | `true`                                               |
 
 ### Outputs


### PR DESCRIPTION
Adds a `use-vitepress` input to the `DocsDocumenter` action. When true, the deploy step uses `DocumenterVitepress.deploydocs()` instead of `Documenter.deploydocs()`.